### PR TITLE
Passed callback function is executed after print dialog is closed.

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -25,6 +25,7 @@
  *      printDelay: 333,            * variable print delay
  *      header: null,               * prefix to html
  *      formValues: true            * preserve input/form values
+ *      callback: function          * function to be called after window.print() finished
  *  });
  *
  * Notes:
@@ -171,7 +172,10 @@
                     $iframe[0].contentWindow.print();
                 }
 
-                $element.trigger("done");
+              // execute passed callback
+              if (typeof opt.callback == 'function') opt.callback.call();
+
+              $element.trigger("done");
                 //remove iframe after print
                 if (!opt.debug) {
                     setTimeout(function() {


### PR DESCRIPTION
Hi,

first of all thank you for your job on this plugin! 

I added this minor change to be able to execute something after print dialog is closed. I think it can be useful in some cases.