### PR TITLE
Excluding elements inside the print area and getting the LESS styles and css inside <style> to be available for print

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -76,13 +76,11 @@
             var $doc = $iframe.contents();
 
             // import page stylesheets
-            if (opt.importCSS) $("link[rel=stylesheet]").each(function() {
-                var href = $(this).attr("href");
-                if (href) {
-                    var media = $(this).attr("media") || "all";
-                    $doc.find("head").append("<link type='text/css' rel='stylesheet' href='" + href + "' media='" + media + "'>")
-                }
-            });
+            if (opt.importCSS) {
+                $("link, style").each(function() {
+                  $doc.find("head").append($(this).clone());
+                });
+            }
 
             //add title of the page
             if (opt.pageTitle) $doc.find("head").append("<title>" + opt.pageTitle + "</title>");


### PR DESCRIPTION
Great plugin guys!!

I made a couple of modifications when i started to use this to help my needs and thought it might be useful to others as well. 

Excluding elements inside the print area, and 
getting the LESS styles and css inside &lt;style&gt; to be available for print

I have tested this in our application and its working beautifully.
