### PR TITLE
Update printThis.js

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -73,6 +73,20 @@
         // $iframe.ready() and $iframe.load were inconsistent between browsers    
         setTimeout(function() {
 
+            // Add doctype to fix the style difference between printing and render
+            function setDocType($iframe,doctype){
+                var win, doc;
+                win = $iframe.get(0);
+                win = win.contentWindow || win.contentDocument || win;
+                doc = win.document || win.contentDocument || win;
+                doc.open();
+                doc.write(doctype);
+                doc.close();
+            }
+            if(opt.doctypeString){
+                setDocType($iframe,opt.doctypeString);
+            }
+
             var $doc = $iframe.contents(),
                 $head = $doc.find("head"),
                 $body = $doc.find("body");
@@ -215,7 +229,8 @@
         removeInline: false,    // remove all inline styles
         printDelay: 333,        // variable print delay
         header: null,           // prefix to html
-        formValues: true        // preserve input/form values
+        formValues: true,        // preserve input/form values
+        doctypeString: '<!DOCTYPE html>' // html doctype
     };
 
     // $.selector container


### PR DESCRIPTION
Add "doctypeString" option to fix the style difference between printing and render.