### PR TITLE
execCommand('print', false, null) & IE meta tag

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -187,8 +187,8 @@
                     $head.append("<script>  window.print(); </script>");
                 } else {
                     // proper method
-                    if (document.queryCommandSupported('print')) {
-                        $iframe[0].contentWindow.document.execCommand('print', false, null);
+                    if (document.queryCommandSupported("print")) {
+                        $iframe[0].contentWindow.document.execCommand("print", false, null);
                     } else {
                         $iframe[0].contentWindow.focus();
                         $iframe[0].contentWindow.print();

--- a/printThis.js
+++ b/printThis.js
@@ -73,6 +73,8 @@
         // $iframe.ready() and $iframe.load were inconsistent between browsers    
         setTimeout(function() {
 
+            if (navigator.userAgent.match(/msie/i)) $iframe[0].contentDocument.write("<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=Edge\"></head><body></body></html>");
+
             var $doc = $iframe.contents(),
                 $head = $doc.find("head"),
                 $body = $doc.find("body");
@@ -187,8 +189,12 @@
                     $head.append("<script>  window.print(); </script>");
                 } else {
                     // proper method
-                    $iframe[0].contentWindow.focus();
-                    $iframe[0].contentWindow.print();
+                    if (document.queryCommandSupported('print')) {
+                        $iframe[0].contentWindow.document.execCommand('print', false, null);
+                    } else {
+                        $iframe[0].contentWindow.focus();
+                        $iframe[0].contentWindow.print();
+                    }
                 }
 
                 //remove iframe after print

--- a/printThis.js
+++ b/printThis.js
@@ -73,8 +73,6 @@
         // $iframe.ready() and $iframe.load were inconsistent between browsers    
         setTimeout(function() {
 
-            if (navigator.userAgent.match(/msie/i)) $iframe[0].contentDocument.write("<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=Edge\"></head><body></body></html>");
-
             var $doc = $iframe.contents(),
                 $head = $doc.find("head"),
                 $body = $doc.find("body");


### PR DESCRIPTION
Utilize execCommand('print', false, null) in browsers that support it to
avoid issues with Internet Explorer. I've been using this method in a
production site with thousands of daily active users since February and
haven't had any reported issues. Close #43. Works in IE8-11, and falls
back to the previous method if the browser doesn't support it.

Also, in IE9, the doctype wasn't being transferred correctly to the
iframe, and was causing display issues, as CSS child selectors only work
if the doctype is set properly. Adding a compatibility meta tag for IE
resolved this issue.