### PR TITLE
add complete event

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -213,6 +213,7 @@
                 if (!opt.debug) {
                     setTimeout(function() {
                         $iframe.remove();
+                        $element.trigger("complete.printThis");
                     }, 1000);
                 }
 


### PR DESCRIPTION
This triggers the `complete.printThis` event after a successful print or if the dialog is simply closed. I have to change some markup to format it properly before printing, but I needed a signal that it was okay to change it back. I'm using this with AngularJS and was running into a few issues too. A timeout seemed hacky and unreliable, so this was a perfect solution.

See a demo here: http://plnkr.co/edit/qTHfT4e4kwlmEgvnOZWJ?p=preview

e.g.

```js
$("#print").printThis();

$("#print").on("complete.printThis", function() {
    alert("Print complete")
});