### PR TITLE
Clone jQuery header/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The amount of time to wait before calling `print()` in the printThis iframe. Def
 Appropriate values depend heavily on the content and network performance. Graphics heavy, slow, or uncached content may need extra time to load.
 
 #### header & footer
-A string or jQuery object to prepend or append to the printThis iframe content. `null` by default. 
+A string or jQuery object to prepend or append to the printThis iframe content. `null` by default.
 
 ```javascript
 $('#mySelector').printThis({
@@ -60,6 +60,8 @@ $('#mySelector').printThis({
     footer: $('.hidden-print-header-content')
 });
 ```
+
+As of 1.9.1, jQuery objects will be cloned rather than moved.
 
 #### base
 The `base` option allows several behaviors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+03/07/2017    Added clone action for header or footer jQuery objects to prevent originals being removed.
+              Bumped to 1.9.1
+
 01/16/2017    Added experimental canvas copy support.
               Added detailed descriptions of advanced options to README
               Bumped to 1.9.0 for new feature (canvas).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "print-this",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "description": "Printing plug-in for jQuery",
     "main": "printThis.js",
     "dependencies": {

--- a/printThis.jquery.json
+++ b/printThis.jquery.json
@@ -1,6 +1,6 @@
 {
   "name": "printThis",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "title": "printThis",
   "description": "Printing plug-in for jQuery. Print specific page elements, add print options, maintain or add new styling using jQuery.",
   "author": {

--- a/printThis.js
+++ b/printThis.js
@@ -1,5 +1,5 @@
 /*
- * printThis v1.9.0
+ * printThis v1.9.1
  * @desc Printing plug-in for jQuery
  * @author Jason Day
  *
@@ -86,8 +86,16 @@
                 doc.write(doctype);
                 doc.close();
             }
+
             if(opt.doctypeString){
                 setDocType($iframe,opt.doctypeString);
+            }
+
+            function appendContent($el, content) {
+                if (!content) return;
+
+                // Simple test for a jQuery element
+                $el.append(content.jquery ? content.clone() : content);
             }
 
             var $doc = $iframe.contents(),
@@ -139,7 +147,7 @@
             }
 
             // print header
-            if (opt.header) $body.append(opt.header);
+            appendContent($body, opt.header);
 
             if (opt.canvas) {
                 // add canvas data-ids for easy access after the cloning.
@@ -230,7 +238,7 @@
             }
 
             // print "footer"
-            if (opt.footer) $body.append(opt.footer);
+            appendContent($body, opt.footer);
 
             setTimeout(function() {
                 if ($iframe.hasClass("MSIE")) {


### PR DESCRIPTION
Adds a test for jQuery elements and uses `.clone()` so the original is not removed from the DOM.
Fixes #99

Discussion points:
1. Is this the desired behavior? I would say so.
2. Should we use `.outerHTML()` instead of `.clone()`? Are there scenarios where there is a functional difference?