### PR TITLE
Use clone(true) to copy form values

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A string or jQuery object to prepend or append to the printThis iframe content. 
 $('#mySelector').printThis({
     header: "<h1>Amazing header</h1>"
 });
- 
+
 $('#mySelector').printThis({
     footer: $('.hidden-print-header-content')
 });
@@ -67,15 +67,13 @@ As of 1.9.1, jQuery objects will be cloned rather than moved.
 The `base` option allows several behaviors.
 By default it is `false`, meaning a the current document will be set as the base URL.  
 
-If set to `true`, a `<base>` attribute will be set if one exists on the page. 
+If set to `true`, a `<base>` attribute will be set if one exists on the page.
 If none is found, the tag is omitted, which may be suitable for pages with Fully Qualified URLs.
 
 When passed as a string, it will be used as the `href` attribute of a `<base>` tag.
 
 #### formValues
-This setting attempts to copy the current values of form elements into the printThis iframe. On by default.
-
-Complex field values, such as those containing quotations or mark-up, may have difficulties. Please report any unexpected behavior.
+This setting copies the current values of form elements into the printThis iframe. On by default.
 
 #### canvas -- Experimental
 As of 1.9.0 you may be able to duplicate canvas elements to the printThis iframe. Disabled by default.
@@ -115,8 +113,4 @@ $("#mySelector").printThis({
 * Every user should be active in the debugging process
 
 ## ToDo:
-* Look at more efficient form field value persist
 * Look at alternative to setTimeout ($.deferred?)
-              
-
-

--- a/printThis.js
+++ b/printThis.js
@@ -48,7 +48,14 @@
 
     function appendBody($body, $element, opt) {
         // Clone for safety and convenience
-        var $content = $element.clone();
+        // Calls clone(withDataAndEvents = true) to copy form values.
+        var $content = $element.clone(opt.formValues);
+
+        if (opt.formValues) {
+            // Copy original select and textarea values to their cloned counterpart
+            // Makes up for inability to clone select and textarea values with clone(true)
+            copyValues($element, $content, 'select, textarea');
+        }
 
         if (opt.removeScripts) {
             $content.find('script').remove();
@@ -56,13 +63,22 @@
 
         if (opt.printContainer) {
             // grab $.selector as container
-            $body.append($("<div/>").html($content).html());
+            $content.appendTo($body);
         } else {
             // otherwise just print interior elements of container
             $content.each(function() {
-                $body.append($(this).html());
+                $(this).children().appendTo($body)
             });
         }
+    }
+
+    // Copies values from origin to clone for passed in elementSelector
+    function copyValues(origin, clone, elementSelector) {
+        var $originalElements = origin.find(elementSelector);
+
+        clone.find(elementSelector).each(function(index, item) {
+            item.value = $originalElements.eq(index).val();
+        });
     }
 
     var opt;
@@ -100,7 +116,7 @@
             top: "-600px"
         });
 
-        // $iframe.ready() and $iframe.load were inconsistent between browsers    
+        // $iframe.ready() and $iframe.load were inconsistent between browsers
         setTimeout(function() {
 
             // Add doctype to fix the style difference between printing and render
@@ -146,7 +162,7 @@
                     $head.append("<link type='text/css' rel='stylesheet' href='" + href + "' media='" + media + "'>");
                 }
             });
-            
+
             // import style tags
             if (opt.importStyle) $("style").each(function() {
                 $(this).clone().appendTo($head);
@@ -191,55 +207,6 @@
                     $src.removeData('printthis');
                 });
             }
-
-            // capture form/field values
-            if (opt.formValues) {
-                // loop through inputs
-                var $input = $element.find('input');
-                if ($input.length) {
-                    $input.each(function() {
-                        var $this = $(this),
-                            $name = $(this).attr('name'),
-                            $checker = $this.is(':checkbox') || $this.is(':radio'),
-                            $iframeInput = $doc.find('input[name="' + $name + '"]'),
-                            $value = $this.val();
-
-                        // order matters here
-                        if (!$checker) {
-                            $iframeInput.val($value);
-                        } else if ($this.is(':checked')) {
-                            if ($this.is(':checkbox')) {
-                                $iframeInput.attr('checked', 'checked');
-                            } else if ($this.is(':radio')) {
-                                $doc.find('input[name="' + $name + '"][value="' + $value + '"]').attr('checked', 'checked');
-                            }
-                        }
-
-                    });
-                }
-
-                // loop through selects
-                var $select = $element.find('select');
-                if ($select.length) {
-                    $select.each(function() {
-                        var $this = $(this),
-                            $name = $(this).attr('name'),
-                            $value = $this.val();
-                        $doc.find('select[name="' + $name + '"]').val($value);
-                    });
-                }
-
-                // loop through textareas
-                var $textarea = $element.find('textarea');
-                if ($textarea.length) {
-                    $textarea.each(function() {
-                        var $this = $(this),
-                            $name = $(this).attr('name'),
-                            $value = $this.val();
-                        $doc.find('textarea[name="' + $name + '"]').val($value);
-                    });
-                }
-            } // end capture form/field values
 
             // remove inline styles
             if (opt.removeInline) {

--- a/printThis.js
+++ b/printThis.js
@@ -77,7 +77,7 @@
         var $originalElements = origin.find(elementSelector);
 
         clone.find(elementSelector).each(function(index, item) {
-            item.value = $originalElements.eq(index).val();
+            $(item).val($originalElements.eq(index).val());
         });
     }
 


### PR DESCRIPTION
Instead of manually iterating over all form elements, this uses `clone(true)` to perform a clone which also copies input data etc.

There are 2 exceptions:
> For performance reasons, the dynamic state of certain form elements (e.g., user data typed into textarea and user selections made to a select) is not copied to the cloned elements
https://api.jquery.com/clone/

Because of this, select and textarea values are manually copied.