### PR TITLE
Add copyTagClasses Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ $("#mySelector").printThis({
     canvas: false,              // copy canvas elements (experimental)
     doctypeString: "...",       // enter a different doctype for older markup
     removeScripts: false,       // remove script tags from print content
-    copyBodyClasses: false      // copy classes from page body tag
+    copyBodyClasses: false,     // copy classes from the page's body tag
+    copyHTMLClasses: false      // copy classes from the page's html tag
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ A doctype string to use on the printThis iframe. Defaults to the HTML5 doctype.
 #### removeScripts
 Deletes script tags from the content to avoid errors or unexpected behavior during print. Disabled by default.
 
-#### copyBodyClasses
-Copies classes from the body tag into the printThis iframe. Disabled by default.
+#### copyTagClasses: false       // copy classes from the html & body tag
+Copies classes from the body and html tags into the printThis iframe. 
+Accepts `true` or test for the strings `"b"` and `"h"` for the body and html tags, respectively. 
+Disabled by default. 
 
 ### All Options
 ```javascript
@@ -108,8 +110,7 @@ $("#mySelector").printThis({
     canvas: false,              // copy canvas elements (experimental)
     doctypeString: "...",       // enter a different doctype for older markup
     removeScripts: false,       // remove script tags from print content
-    copyBodyClasses: false,     // copy classes from the page's body tag
-    copyHTMLClasses: false      // copy classes from the page's html tag
+    copyTagClasses: false       // copy classes from the html & body tag
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Printing plug-in for jQuery
 * Preserve page CSS/styling
 ** or add new CSS; the world is your oyster!
 * Preserve form entries
-* **1.9.0 adds experimental canvas support**
+* **Canvas support (experimental)**
 
 ## Usage
 ### Basic
@@ -85,7 +85,10 @@ This has received only limited testing and so may not work in all browsers and s
 A doctype string to use on the printThis iframe. Defaults to the HTML5 doctype.
 
 #### removeScripts
-Deletes script tags from the content to avoid errors or unexpected behavior during print.
+Deletes script tags from the content to avoid errors or unexpected behavior during print. Disabled by default.
+
+#### copyBodyClasses
+Copies classes from the body tag into the printThis iframe. Disabled by default.
 
 ### All Options
 ```javascript
@@ -104,7 +107,8 @@ $("#mySelector").printThis({
     formValues: true,           // preserve input/form values
     canvas: false,              // copy canvas elements (experimental)
     doctypeString: "...",       // enter a different doctype for older markup
-    removeScripts: false        // remove script tags from print content
+    removeScripts: false,       // remove script tags from print content
+    copyBodyClasses: false      // copy classes from page body tag
 });
 ```
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-07/31/2017    Added copyBodyClasses & copyHTMLClasses, disabled by default, to copy body & html tag classes of the page
+08/01/2017    Added copyTagClasses, disabled by default, to copy body & html tag classes from the page
               Updated README documentation for removeScripts
               Updated README to remove old versions number from canvas support to prevent confusion
               Bumped to 1.11.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
+07/29/2017    Added copyBodyClasses, disabled by default, to copy classes from the parent page body tag
+              Updated README documentation for removeScripts
+              Updated README to remove old versions number from canvas support to prevent confusion
+              Bumped to 1.11.0
+
 04/06/2017    Added action, disabled by default, to avoid bringing unwanted scripts into the print iframe.
-              Removed undocumented helper function $.fn.outer.
+              Removed undocumented helper function $.fn.outer
               Reformatted example text with valid JS comments
               Bumped to 1.10.0 for new feature (removeScripts)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-07/29/2017    Added copyBodyClasses, disabled by default, to copy classes from the parent page body tag
+07/31/2017    Added copyBodyClasses & copyHTMLClasses, disabled by default, to copy body & html tag classes of the page
               Updated README documentation for removeScripts
               Updated README to remove old versions number from canvas support to prevent confusion
               Bumped to 1.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "print-this",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "Printing plug-in for jQuery",
     "main": "printThis.js",
     "dependencies": {

--- a/printThis.jquery.json
+++ b/printThis.jquery.json
@@ -1,6 +1,6 @@
 {
   "name": "printThis",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "title": "printThis",
   "description": "Printing plug-in for jQuery. Print specific page elements, add print options, maintain or add new styling using jQuery.",
   "author": {

--- a/printThis.js
+++ b/printThis.js
@@ -31,7 +31,8 @@
  *      canvas: false,              // copy canvas elements (experimental)
  *      doctypeString: '...',       // enter a different doctype for older markup
  *      removeScripts: false,       // remove script tags from print content
- *      copyBodyClasses: false      // copy classes from page body tag
+ *      copyBodyClasses: false,     // copy classes from the page's body tag
+ *      copyHTMLClasses: false      // copy classes from the page's html tag
  *  });
  *
  * Notes:
@@ -167,9 +168,14 @@
                 }
             }
 
-            // Append classes from page body tag
+            // Get classes from the page's body tag
             if (opt.copyBodyClasses) {
                 $body.addClass($('body')[0].className);
+            }
+
+            // Get classes from the page's html tag
+            if (opt.copyHTMLClasses) {
+                $doc.find('html').addClass($('html')[0].className);
             }
 
             // print header
@@ -306,6 +312,7 @@
         base: false,            // preserve the BASE tag, or accept a string for the URL
         doctypeString: '<!DOCTYPE html>', // html doctype
         removeScripts: false,    // remove script tags before appending
-        copyBodyClasses: false   // copy classes from page body tag
+        copyBodyClasses: false,     // copy classes from the page's body tag
+        copyHTMLClasses: false      // copy classes from the page's html tag
     };
 })(jQuery);

--- a/printThis.js
+++ b/printThis.js
@@ -1,5 +1,5 @@
 /*
- * printThis v1.10.0
+ * printThis v1.11.0
  * @desc Printing plug-in for jQuery
  * @author Jason Day
  *
@@ -30,7 +30,8 @@
  *      formValues: true,           // preserve input/form values
  *      canvas: false,              // copy canvas elements (experimental)
  *      doctypeString: '...',       // enter a different doctype for older markup
- *      removeScripts: false        // remove script tags from print content
+ *      removeScripts: false,       // remove script tags from print content
+ *      copyBodyClasses: false      // copy classes from page body tag
  *  });
  *
  * Notes:
@@ -166,6 +167,11 @@
                 }
             }
 
+            // Append classes from page body tag
+            if (opt.copyBodyClasses) {
+                $body.addClass($('body')[0].className);
+            }
+
             // print header
             appendContent($body, opt.header);
 
@@ -299,6 +305,7 @@
         canvas: false,          // copy canvas content (experimental)
         base: false,            // preserve the BASE tag, or accept a string for the URL
         doctypeString: '<!DOCTYPE html>', // html doctype
-        removeScripts: false    // remove script tags before appending
+        removeScripts: false,    // remove script tags before appending
+        copyBodyClasses: false   // copy classes from page body tag
     };
 })(jQuery);

--- a/printThis.js
+++ b/printThis.js
@@ -101,6 +101,7 @@
             top: "-600px"
         });
 
+        // $iframe.ready() and $iframe.load were inconsistent between browsers
         setTimeout(function() {
 
             // Add doctype to fix the style difference between printing and render
@@ -146,6 +147,7 @@
                     $head.append("<link type='text/css' rel='stylesheet' href='" + href + "' media='" + media + "'>");
                 }
             });
+
             // import style tags
             if (opt.importStyle) $("style").each(function() {
                 $(this).clone().appendTo($head);
@@ -156,20 +158,25 @@
 
             // import additional stylesheet(s)
             if (opt.loadCSS) {
+                if ($.isArray(opt.loadCSS)) {
                     jQuery.each(opt.loadCSS, function(index, value) {
+                        $head.append("<link type='text/css' rel='stylesheet' href='" + this + "'>");
                     });
                 } else {
                     $head.append("<link type='text/css' rel='stylesheet' href='" + opt.loadCSS + "'>");
                 }
             }
 
-            // Get classes from the page's body tag
-            if (opt.copyBodyClasses) {
-                $body.addClass($('body')[0].className);
-            }
-
-            // Get classes from the page's html tag
-            if (opt.copyHTMLClasses) {
+            // copy 'root' tag classes
+            var tag = opt.copyTagClasses;
+            if (tag) {
+                tag = tag === true ? 'bh' : tag;
+                if (tag.indexOf('b') !== -1) {
+                    $body.addClass($('body')[0].className);
+                }
+                if (tag.indexOf('h') !== -1) {
+                    $doc.find('html').addClass($('html')[0].className);
+                }
             }
 
             // print header
@@ -305,8 +312,7 @@
         canvas: false,          // copy canvas content (experimental)
         base: false,            // preserve the BASE tag, or accept a string for the URL
         doctypeString: '<!DOCTYPE html>', // html doctype
-        removeScripts: false,    // remove script tags before appending
-        copyBodyClasses: false,     // copy classes from the page's body tag
-        copyHTMLClasses: false      // copy classes from the page's html tag
+        removeScripts: false,   // remove script tags before appending
+        copyTagClasses: false   // copy classes from the html & body tag
     };
 })(jQuery);

--- a/printThis.js
+++ b/printThis.js
@@ -31,8 +31,7 @@
  *      canvas: false,              // copy canvas elements (experimental)
  *      doctypeString: '...',       // enter a different doctype for older markup
  *      removeScripts: false,       // remove script tags from print content
- *      copyBodyClasses: false,     // copy classes from the page's body tag
- *      copyHTMLClasses: false      // copy classes from the page's html tag
+ *      copyTagClasses: false       // copy classes from the html & body tag
  *  });
  *
  * Notes:
@@ -102,7 +101,6 @@
             top: "-600px"
         });
 
-        // $iframe.ready() and $iframe.load were inconsistent between browsers    
         setTimeout(function() {
 
             // Add doctype to fix the style difference between printing and render
@@ -148,7 +146,6 @@
                     $head.append("<link type='text/css' rel='stylesheet' href='" + href + "' media='" + media + "'>");
                 }
             });
-            
             // import style tags
             if (opt.importStyle) $("style").each(function() {
                 $(this).clone().appendTo($head);
@@ -159,9 +156,7 @@
 
             // import additional stylesheet(s)
             if (opt.loadCSS) {
-               if ($.isArray(opt.loadCSS)) {
                     jQuery.each(opt.loadCSS, function(index, value) {
-                       $head.append("<link type='text/css' rel='stylesheet' href='" + this + "'>");
                     });
                 } else {
                     $head.append("<link type='text/css' rel='stylesheet' href='" + opt.loadCSS + "'>");
@@ -175,7 +170,6 @@
 
             // Get classes from the page's html tag
             if (opt.copyHTMLClasses) {
-                $doc.find('html').addClass($('html')[0].className);
             }
 
             // print header


### PR DESCRIPTION
In response to discussion on #118 and #119, here is an alternative proposal to use a single configuration object to copy classes for body and html tags.