### PR TITLE
Allow later jQuery versions than 1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Printing plug-in for jQuery",
     "main": "printThis.js",
     "dependencies": {
-        "jquery": "~1.11"
+        "jquery": ">=1.11"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Previously only jQuery 1.11.* matched the pattern in package.json, which will make all package managers install this specific version of jQuery.

I could imagine that many people don't really discover this since the "extra" installed version is not used anywhere. But if you are using webpack, which is really good at separating modules even if they have the same name, you end up having two different versions of jQuery running in parallel - one version where the printThis plugin is installed, and one other version where it is not installed. That turns out to be ridiculously hard to debug. 😅 

The composer.json file already specifies a jQuery version higher or equal to 1.11, and the plugin seems to work just fine on jQuery 2 and 3.
