### PR TITLE
support css var change by javascript

### DIFF
--- a/printThis.js
+++ b/printThis.js
@@ -183,6 +183,9 @@
                 }
             }
 
+            // CSS VAR in html tag when dynamic apply e.g.  document.documentElement.style.setProperty("--foo", bar);
+            $doc.find('html').prop('style', $('html')[0].style.cssText)
+
             // copy 'root' tag classes
             var tag = opt.copyTagClasses;
             if (tag) {


### PR DESCRIPTION
if you use css variable and change them with js,  e.g. `document.documentElement.style.setProperty("--foo", bar);`, it wont include when we print. So, i add a line to copy inline style from html tag to html tag inside iframe