### PR TITLE
Remove inline styles from custom selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Use a custom page title on the iframe. This may be reflected on the printed page
 #### removeInline
 Eliminates any inline style attributes from the content. Off by default.
 
+#### removeInlineSelector
+Eliminates custom inline style attributes from the content. Off by default. Requires removeInline to be true
+Excepts custom jquery selectors. Default is "body *"
+
 #### printDelay
 The amount of time to wait before calling `print()` in the printThis iframe. Defaults to 333 milliseconds.
 Appropriate values depend heavily on the content and network performance. Graphics heavy, slow, or uncached content may need extra time to load.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use a custom page title on the iframe. This may be reflected on the printed page
 Eliminates any inline style attributes from the content. Off by default.
 
 #### removeInlineSelector
-Eliminates custom inline style attributes from the content. Off by default. Requires removeInline to be true
+Eliminates custom inline style attributes from the content. Off by default. Requires removeInline to be true.
 Excepts custom jquery selectors. Default is "body *"
 
 #### printDelay

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Eliminates any inline style attributes from the content. Off by default.
 
 #### removeInlineSelector
 Eliminates custom inline style attributes from the content. Off by default. Requires removeInline to be true.
-Excepts custom jquery selectors. Default is "body *"
+Excepts custom jquery selectors. Default is "*"
 
 #### printDelay
 The amount of time to wait before calling `print()` in the printThis iframe. Defaults to 333 milliseconds.

--- a/printThis.js
+++ b/printThis.js
@@ -23,6 +23,7 @@
  *      loadCSS: "path/to/my.css",  // path to additional css file - us an array [] for multiple
  *      pageTitle: "",              // add title to print page
  *      removeInline: false,        // remove all inline styles from print elements
+ *      removeInlineSelector: "body *", //  custom jquery selectors for remove selected inline styles. (removeInline = true required)
  *      printDelay: 333,            // variable print delay
  *      header: null,               // prefix to html
  *      footer: null,               // postfix to html
@@ -226,9 +227,9 @@
             if (opt.removeInline) {
                 // $.removeAttr available jQuery 1.7+
                 if ($.isFunction($.removeAttr)) {
-                    $doc.find("body *").removeAttr("style");
+                    $doc.find(opt.removeInlineSelector).removeAttr("style");
                 } else {
-                    $doc.find("body *").attr("style", "");
+                    $doc.find(opt.removeInlineSelector).attr("style", "");
                 }
             }
 
@@ -273,6 +274,7 @@
         loadCSS: "",            // load an additional css file - load multiple stylesheets with an array []
         pageTitle: "",          // add title to print page
         removeInline: false,    // remove all inline styles
+        removeInlineSelector: "body *", // custom jquery selectors for remove selected inline styles. (removeInline = true required)
         printDelay: 333,        // variable print delay
         header: null,           // prefix to html
         footer: null,           // postfix to html

--- a/printThis.js
+++ b/printThis.js
@@ -227,9 +227,9 @@
             if (opt.removeInline) {
                 // $.removeAttr available jQuery 1.7+
                 if ($.isFunction($.removeAttr)) {
-                    $doc.find(opt.removeInlineSelector).removeAttr("style");
+                    $body.find(opt.removeInlineSelector).removeAttr("style");
                 } else {
-                    $doc.find(opt.removeInlineSelector).attr("style", "");
+                    $body.find(opt.removeInlineSelector).attr("style", "");
                 }
             }
 
@@ -274,7 +274,7 @@
         loadCSS: "",            // load an additional css file - load multiple stylesheets with an array []
         pageTitle: "",          // add title to print page
         removeInline: false,    // remove all inline styles
-        removeInlineSelector: "body *", // custom jquery selectors for remove selected inline styles. (removeInline = true required)
+        removeInlineSelector: "*", // custom jquery selectors for remove selected inline styles. (removeInline = true required)
         printDelay: 333,        // variable print delay
         header: null,           // prefix to html
         footer: null,           // postfix to html


### PR DESCRIPTION
Dear Jason Day,

Thank you for the great plugin. 
I run into a situation where I had to remove most of a inline styles from the page expect the table column widths. They were generated by a third party library. So I add a new option called "removeInlineSelector" which gives the users a chance to fine tune the removing process. 

Kind regards,

Kory
